### PR TITLE
Build legacy duplicity for Debian Bullseye (tklbam dependency)

### DIFF
--- a/duplicity/_librsyncmodule.c
+++ b/duplicity/_librsyncmodule.c
@@ -60,8 +60,8 @@ _librsync_new_sigmaker(PyObject* self, PyObject* args)
   if (sm == NULL) return NULL;
   sm->x_attr = NULL;
 
-  sm->sig_job = rs_sig_begin((size_t)blocklen,
-                             (size_t)RS_DEFAULT_STRONG_LEN);
+  sm->sig_job = rs_sig_begin((size_t)blocklen, 8,
+                             (size_t)RS_MD4_SIG_MAGIC);
   return (PyObject*)sm;
 }
 

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ from distutils.core import setup, Extension
 
 version_string = "0.6.18"
 
-if sys.version_info[:2] < (2,4):
-    print "Sorry, duplicity requires version 2.4 or later of python"
+if sys.version_info[:2] != (2,7):
+    print("Sorry, duplicity requires version 2.7 of python")
     sys.exit(1)
 
 incdir_list = libdir_list = None


### PR DESCRIPTION
Build legacy duplicity for Debian Bullseye (tklbam dependency)